### PR TITLE
Fix8 change n count and add BP user input

### DIFF
--- a/man/plotMoonlight.Rd
+++ b/man/plotMoonlight.Rd
@@ -11,6 +11,7 @@ plotMoonlight(
   gene_type = "drivers",
   n = 50,
   genelist = c(),
+  BPlist = c(),
   additionalFilename = ""
 )
 }
@@ -32,6 +33,9 @@ plotMoonlight(
 
 \item{genelist}{A vector of strings containing Hugo Symbols of genes. 
 Overwrites \code{gene_type} argument.}
+
+\item{BPlist}{A vector of strings. Selection of the biological processes to visualise.
+If left empty defaults to every BP provided in the URA file.}
 
 \item{additionalFilename}{A character string. Adds prefix or filepath to the filename of the pdf.}
 }


### PR DESCRIPTION
This fixes the bug and enhancement mentioned in Issue 8. 

The n variable now takes the number of BPs into account, so n is actually the number of genes appearing on the plot. 
A new variable is added 'BPlist' which makes it possible to select only some of the BPs in the URA file, e.g in case the user have used the machine learning approach and dont want all 101 BPs to show on the plot. 

